### PR TITLE
Fixed incorrect CIN when sending system messages

### DIFF
--- a/src/USB-MIDI.h
+++ b/src/USB-MIDI.h
@@ -74,7 +74,7 @@ public:
         else {
             // Only System messages
             cin = system2cin[status & 0x0F][1];
-            mPacket.header = MAKEHEADER(cableNumber, 0x04);
+            mPacket.header = MAKEHEADER(cableNumber, cin);
         }
         
         mPacket.byte1 = mPacket.byte2 = mPacket.byte3  = 0;


### PR DESCRIPTION
Fix for #8 .

Fixed an issue where the CIN was set to 4 when sending system messages other than SysEx.

