### PR TITLE
Add custom instance macro

### DIFF
--- a/src/USB-MIDI.h
+++ b/src/USB-MIDI.h
@@ -177,5 +177,9 @@ END_USBMIDI_NAMESPACE
     USBMIDI_NAMESPACE::usbMidiTransport __usb##Name(CableNr);\
     MIDI_NAMESPACE::MidiInterface<USBMIDI_NAMESPACE::usbMidiTransport> Name((USBMIDI_NAMESPACE::usbMidiTransport&)__usb##Name);
 
+#define USBMIDI_CREATE_CUSTOM_INSTANCE(CableNr, Name, Settings)  \
+    USBMIDI_NAMESPACE::usbMidiTransport __usb##Name(CableNr);\
+    MIDI_NAMESPACE::MidiInterface<USBMIDI_NAMESPACE::usbMidiTransport, Settings> Name((USBMIDI_NAMESPACE::usbMidiTransport&)__usb##Name);
+
 #define USBMIDI_CREATE_DEFAULT_INSTANCE()  \
     USBMIDI_CREATE_INSTANCE(0, MIDI)


### PR DESCRIPTION
Adds a macro for creating a custom instance of `MidiInterface`. This will allow users to override settings like `SysExMaxSize`.

I am no C++ programmer, so most of this is just a copy/paste job, but I did test this out in my project and it does work.

Happy to address any issues you see!